### PR TITLE
fix: restrict CORS to specific origins instead of wildcard

### DIFF
--- a/backend/app/config/base.py
+++ b/backend/app/config/base.py
@@ -20,6 +20,9 @@ class Settings(BaseSettings):
     # Session settings
     SESSION_SECRET_KEY: str  # Required from .env
 
+    # CORS settings
+    ALLOWED_ORIGINS: list[str] = ["http://localhost:5173"]  # Default safe origin
+
     # Cache settings
     CACHE_TTL: int = 3600 # 1 hour default
     CACHE_MAX_SIZE: int = 1000 # Default max size

--- a/backend/app/config/dev.py
+++ b/backend/app/config/dev.py
@@ -26,6 +26,9 @@ class DevSettings(Settings):  # Inherit from base Settings
     # API_URL - Specific dev override
     API_URL: str = "http://localhost:8000"
 
+    # CORS settings - Dev allows localhost frontend
+    ALLOWED_ORIGINS: list = ["http://localhost:5173"]
+
     # Cache settings will be inherited from Settings unless overridden here
     # CACHE_TTL: int = 3600
     # CACHE_MAX_SIZE: int = 1000

--- a/backend/app/config/prod.py
+++ b/backend/app/config/prod.py
@@ -30,6 +30,11 @@ class ProdSettings(Settings): # Inherit from base Settings
 
     # API_URL - should be the production API URL, loaded from .env via Settings
     # API_URL: str = os.getenv("API_URL", "http://localhost:8000") # Example
-    
+
     # FRONTEND_URL: str = os.getenv("FRONTEND_URL", "http://localhost:5173") # Example
+
+    # CORS settings
+    # Production: set ALLOWED_ORIGINS in .env to comma-separated list
+    # Example: ALLOWED_ORIGINS='["https://yourdomain.com","https://app.yourdomain.com"]'
+    ALLOWED_ORIGINS: list[str] = []  # Prod must explicitly set origins in .env
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -70,10 +70,10 @@ app = FastAPI(
 # Configuration CORS
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=settings.ALLOWED_ORIGINS,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization"],
 )
 
 # Session middleware

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -101,3 +101,38 @@ def test_session_secret_key_can_be_provided(tmp_path):
         assert settings.SESSION_SECRET_KEY == test_secret
     finally:
         os.chdir(original_cwd)
+
+
+def test_allowed_origins_is_list():
+    """ALLOWED_ORIGINS must be a list of specific origins"""
+    with patch.dict(os.environ, {
+        "SESSION_SECRET_KEY": "test-secret",
+        "TWITCH_CLIENT_ID": "test-id",
+        "TWITCH_CLIENT_SECRET": "test-secret",
+        "MONGODB_URL": "mongodb://test",
+        "REDIS_URL": "redis://test",
+        "ALLOWED_ORIGINS": '["http://localhost:5173","https://example.com"]'
+    }):
+        from backend.app.config.base import Settings
+        settings = Settings()
+        assert isinstance(settings.ALLOWED_ORIGINS, list)
+        assert "http://localhost:5173" in settings.ALLOWED_ORIGINS
+        assert "https://example.com" in settings.ALLOWED_ORIGINS
+        assert "*" not in settings.ALLOWED_ORIGINS
+
+
+def test_allowed_origins_default():
+    """ALLOWED_ORIGINS must have safe defaults per environment"""
+    with patch.dict(os.environ, {
+        "SESSION_SECRET_KEY": "test-secret",
+        "TWITCH_CLIENT_ID": "test-id",
+        "TWITCH_CLIENT_SECRET": "test-secret",
+        "MONGODB_URL": "mongodb://test",
+        "REDIS_URL": "redis://test",
+        "ENVIRONMENT": "dev"
+    }):
+        from backend.app.config.dev import DevSettings
+        settings = DevSettings()
+        # Dev should have localhost
+        assert "http://localhost:5173" in settings.ALLOWED_ORIGINS
+        assert "*" not in settings.ALLOWED_ORIGINS


### PR DESCRIPTION
## Summary
- Removed allow_origins=['*'] + allow_credentials=True vulnerability
- Added ALLOWED_ORIGINS configuration list
- Dev defaults to http://localhost:5173
- Prod requires explicit configuration in .env
- Only allows GET, POST, PUT, DELETE, OPTIONS methods
- Only allows Content-Type and Authorization headers
- Prevents CSRF and unauthorized cross-origin requests

## Changes
- `backend/app/config/base.py`: Added ALLOWED_ORIGINS with safe default
- `backend/app/config/dev.py`: Set dev origins to localhost:5173
- `backend/app/config/prod.py`: Prod requires explicit .env config
- `backend/app/main.py`: Use ALLOWED_ORIGINS, restrict methods/headers
- `tests/unit/config/test_settings.py`: Added CORS validation tests

## Test Results
✅ All test cases passing:
- `test_allowed_origins_is_list`
- `test_allowed_origins_default`