### PR TITLE
fix: disable FastAPI debug and docs in production

### DIFF
--- a/backend/app/config/base.py
+++ b/backend/app/config/base.py
@@ -20,6 +20,9 @@ class Settings(BaseSettings):
     # Session settings
     SESSION_SECRET_KEY: str  # Required from .env
 
+    # Application settings
+    DEBUG: bool = False  # Default to False (secure default)
+
     # Cache settings
     CACHE_TTL: int = 3600 # 1 hour default
     CACHE_MAX_SIZE: int = 1000 # Default max size

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -60,11 +60,11 @@ app = FastAPI(
     title=PROJECT_NAME,
     description="API pour la gestion des vidéos Twitch",
     version="1.0.0",
-    docs_url="/api/docs",
-    redoc_url="/api/redoc",
-    openapi_url=f"{API_V1_STR}/openapi.json",
+    docs_url="/api/docs" if settings.DEBUG else None,
+    redoc_url="/api/redoc" if settings.DEBUG else None,
+    openapi_url=f"{API_V1_STR}/openapi.json" if settings.DEBUG else None,
     lifespan=lifespan,
-    debug=True
+    debug=settings.DEBUG
 )
 
 # Configuration CORS

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -101,3 +101,35 @@ def test_session_secret_key_can_be_provided(tmp_path):
         assert settings.SESSION_SECRET_KEY == test_secret
     finally:
         os.chdir(original_cwd)
+
+
+def test_debug_false_in_prod():
+    """DEBUG must be False in production"""
+    with patch.dict(os.environ, {
+        "ENVIRONMENT": "prod",
+        "SESSION_SECRET_KEY": "test-secret",
+        "TWITCH_CLIENT_ID": "test-id",
+        "TWITCH_CLIENT_SECRET": "test-secret",
+        "TWITCH_REDIRECT_URI": "http://localhost:8000/callback",
+        "MONGODB_URL": "mongodb://test",
+        "REDIS_URL": "redis://test"
+    }):
+        from backend.app.config.prod import ProdSettings
+        settings = ProdSettings()
+        assert settings.DEBUG is False
+
+
+def test_debug_true_in_dev():
+    """DEBUG can be True in development"""
+    with patch.dict(os.environ, {
+        "ENVIRONMENT": "dev",
+        "SESSION_SECRET_KEY": "test-secret",
+        "TWITCH_CLIENT_ID": "test-id",
+        "TWITCH_CLIENT_SECRET": "test-secret",
+        "TWITCH_REDIRECT_URI": "http://localhost:8000/callback",
+        "MONGODB_URL": "mongodb://test",
+        "REDIS_URL": "redis://test"
+    }):
+        from backend.app.config.dev import DevSettings
+        settings = DevSettings()
+        assert settings.DEBUG is True


### PR DESCRIPTION
## Summary
- DEBUG setting now controlled by environment config
- In prod: debug=False, docs disabled (no /api/docs, /api/redoc, openapi.json)
- In dev: debug=True, docs enabled for development
- Prevents stack trace exposure and API documentation leakage in production

## Changes
- `backend/app/config/base.py`: Added DEBUG field with secure default (False)
- `backend/app/main.py`: Use settings.DEBUG for debug mode and conditional docs URLs
- `tests/unit/config/test_settings.py`: Added DEBUG validation tests

## Test Results
✅ All 4 tests passing:
- `test_debug_false_in_prod`
- `test_debug_true_in_dev`