### PR TITLE
fix: remove secrets from startup logging

### DIFF
--- a/backend/app/config/__init__.py
+++ b/backend/app/config/__init__.py
@@ -2,6 +2,9 @@ from .dev import DevSettings
 from .prod import ProdSettings
 from .test import TestSettings
 import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 def get_settings():
     """Get settings based on environment"""
@@ -18,12 +21,7 @@ ENV = os.getenv("ENVIRONMENT", "prod")
 # Get settings based on environment
 settings = get_settings()
 
-# Debug print
-print(f"Current environment: {ENV}")
-print(f"TWITCH_REDIRECT_URI: {settings.TWITCH_REDIRECT_URI}")
-print(f"TWITCH_CLIENT_ID: {settings.TWITCH_CLIENT_ID}")
-print(f"MONGODB_URL: {settings.MONGODB_URL}")
-print(f"MONGODB_DB_NAME: {settings.MONGODB_DB_NAME}")
-print(f"REDIS_URL: {settings.REDIS_URL}")
+# Safe startup logging (no secrets)
+logger.info(f"Environment: {ENV}")
 
 __all__ = ["settings", "get_settings"] 

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -101,3 +101,16 @@ def test_session_secret_key_can_be_provided(tmp_path):
         assert settings.SESSION_SECRET_KEY == test_secret
     finally:
         os.chdir(original_cwd)
+
+
+def test_settings_init_does_not_log_secrets():
+    """Settings initialization must not print secrets to stdout"""
+    with open('/srv/13Perso_projet/StreamZilla/backend/app/config/__init__.py', 'r') as f:
+        content = f.read()
+        # Should not contain print statements that output sensitive values
+        assert 'TWITCH_CLIENT_ID' not in content or 'print' not in content, \
+            "Config __init__.py must not print TWITCH_CLIENT_ID"
+        assert 'MONGODB_URL' not in content or 'print' not in content, \
+            "Config __init__.py must not print MONGODB_URL"
+        assert 'REDIS_URL' not in content or 'print' not in content, \
+            "Config __init__.py must not print REDIS_URL"


### PR DESCRIPTION
## Summary
- Removed print statements that logged TWITCH_CLIENT_ID, MONGODB_URL, REDIS_URL, etc.
- Replaced with safe logging: environment name only
- Prevents credential leakage via application startup logs

## Changes
- `backend/app/config/__init__.py`: Removed 6 print() statements, replaced with logger.info()
- `tests/unit/config/test_settings.py`: Added test verifying no secrets in config init

## Test Results
✅ All 3 config tests passing