### PR TITLE
fix: remove sensitive data from request and API logging

### DIFF
--- a/backend/app/middleware/logging.py
+++ b/backend/app/middleware/logging.py
@@ -6,29 +6,29 @@ from starlette.types import ASGIApp
 
 logger = logging.getLogger(__name__)
 
+
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
     def __init__(self, app: ASGIApp):
         super().__init__(app)
 
     async def dispatch(self, request: Request, call_next):
         start_time = time.time()
-        
-        # Log la requête entrante
-        logger.warning(f"[Request] {request.method} {request.url.path}")
-        logger.warning(f"[Request Headers] {dict(request.headers)}")
-        
-        # Exécute la requête
+
+        # Log request: only method and path (no headers)
+        logger.info(f"{request.method} {request.url.path}")
+
+        # Execute request
         response = await call_next(request)
-        
-        # Calcule la durée
+
+        # Calculate duration
         process_time = (time.time() - start_time) * 1000
         formatted_process_time = '{0:.2f}'.format(process_time)
-        
-        # Log la réponse
-        logger.warning(
-            f"[Response] {request.method} {request.url.path} - "
-            f"Status: {response.status_code} - "
-            f"Duration: {formatted_process_time}ms"
+
+        # Log response: status and duration
+        logger.info(
+            f"{request.method} {request.url.path} - "
+            f"{response.status_code} - "
+            f"{formatted_process_time}ms"
         )
-        
-        return response 
+
+        return response

--- a/backend/app/services/twitch_service.py
+++ b/backend/app/services/twitch_service.py
@@ -191,8 +191,7 @@ class TwitchService:
     async def _find_game(self, game_name: str, headers: dict) -> Optional[TwitchGame]:
         """Recherche un jeu sur Twitch."""
         try:
-            logger.warning(f"[Twitch API Request] GET /search/categories - Params: query={game_name}, first=1")
-            logger.warning(f"[Twitch API Request] Headers: {headers}")
+            logger.debug(f"[Twitch API] GET /search/categories - query={game_name}")
             
             response = await self.client.get(
                 f"{self.base_url}/search/categories",
@@ -200,8 +199,7 @@ class TwitchService:
                 headers=headers
             )
             
-            logger.warning(f"[Twitch API Response] Status: {response.status_code}")
-            logger.warning(f"[Twitch API Response] Body: {response.json()}")
+            logger.debug(f"[Twitch API] GET /search/categories - Status: {response.status_code}")
             
             response.raise_for_status()
             data = response.json()
@@ -236,8 +234,7 @@ class TwitchService:
             if cursor:
                 stream_params["after"] = cursor
 
-            logger.info(f"[Twitch API Request] GET /streams - Params: {stream_params}")
-            logger.info(f"[Twitch API Request] Headers: {headers}")
+            logger.debug(f"[Twitch API] GET /streams - Params: {stream_params}")
 
             stream_response = await self.client.get(
                 f"{self.base_url}/streams",
@@ -245,8 +242,7 @@ class TwitchService:
                 headers=headers
             )
             
-            logger.info(f"[Twitch API Response] Status: {stream_response.status_code}")
-            logger.info(f"[Twitch API Response] Body: {stream_response.json()}")
+            logger.debug(f"[Twitch API] GET /streams - Status: {stream_response.status_code}")
             
             stream_response.raise_for_status()
             stream_data = stream_response.json()
@@ -284,8 +280,7 @@ class TwitchService:
                     "type": "archive"
                 }
 
-                logger.info(f"[Twitch API Request] GET /videos - Params: {video_params}")
-                logger.info(f"[Twitch API Request] Headers: {headers}")
+                logger.debug(f"[Twitch API] GET /videos - Params: {video_params}")
 
                 video_response = await self.client.get(
                     f"{self.base_url}/videos",
@@ -293,8 +288,7 @@ class TwitchService:
                     headers=headers
                 )
                 
-                logger.info(f"[Twitch API Response] Status: {video_response.status_code}")
-                logger.info(f"[Twitch API Response] Body: {video_response.json()}")
+                logger.debug(f"[Twitch API] GET /videos - Status: {video_response.status_code}")
                 
                 video_response.raise_for_status()
                 video_data = video_response.json()

--- a/tests/unit/middleware/test_logging.py
+++ b/tests/unit/middleware/test_logging.py
@@ -1,0 +1,21 @@
+import pytest
+import inspect
+from backend.app.middleware.logging import RequestLoggingMiddleware
+
+
+def test_logging_middleware_does_not_log_headers():
+    """Logging middleware must not log dict(request.headers)"""
+    source = inspect.getsource(RequestLoggingMiddleware.dispatch)
+    assert 'dict(request.headers)' not in source, \
+        "Middleware must not log dict(request.headers)"
+    assert 'request.headers' not in source, \
+        "Middleware must not log request.headers in any form"
+
+
+def test_logging_middleware_logs_method_and_path():
+    """Middleware should log request method and path"""
+    source = inspect.getsource(RequestLoggingMiddleware.dispatch)
+    assert 'request.method' in source, \
+        "Middleware should log request method"
+    assert 'request.url.path' in source, \
+        "Middleware should log request path"


### PR DESCRIPTION
## Summary
- Middleware no longer logs complete request headers (Authorization, Cookie, tokens)
- Only logs method, path, status code, and duration
- Twitch API calls no longer log Bearer tokens or full response bodies
- API logging changed from WARNING/INFO to DEBUG level

## Changes
- `backend/app/middleware/logging.py`: Removed dict(request.headers) logging
- `backend/app/services/twitch_service.py`: Removed 12 lines of header/body logging, replaced with 6 concise DEBUG lines
- `tests/unit/middleware/test_logging.py`: Added tests verifying no sensitive data logged

## Test Results
✅ All middleware tests passing:
- `test_logging_middleware_does_not_log_headers`
- `test_logging_middleware_logs_method_and_path`