### PR TITLE
fix(logging): normalize log levels and make root level configurable

### DIFF
--- a/backend/app/config/base.py
+++ b/backend/app/config/base.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
 
     # Application settings
     DEBUG: bool = False  # Default to False (secure default)
+    LOG_LEVEL: str = "INFO"
     # CORS settings
     ALLOWED_ORIGINS: list[str] = ["http://localhost:5173"]  # Default safe origin
 

--- a/backend/app/config/logging_config.py
+++ b/backend/app/config/logging_config.py
@@ -1,8 +1,12 @@
 import logging
+import os
 import sys
 
+
 def setup_logging():
-    # Configuration du handler de base
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(
         logging.Formatter(
@@ -11,25 +15,6 @@ def setup_logging():
         )
     )
 
-    # Configuration du logger root
     root_logger = logging.getLogger()
-    root_logger.setLevel(logging.WARNING)  # Niveau global WARNING
-    root_logger.addHandler(handler)
-
-    # Configuration spécifique pour nos loggers
-    twitch_loggers = [
-        logging.getLogger("backend.app.services.twitch"),
-        logging.getLogger("backend.app.services.twitch_service"),
-        logging.getLogger("backend.app.services.twitch.auth")
-    ]
-
-    for logger in twitch_loggers:
-        logger.setLevel(logging.WARNING)  # Force le niveau WARNING pour Twitch
-        if not logger.handlers:
-            logger.addHandler(handler)
-        logger.propagate = True  # Permet la propagation vers le logger root
-
-    # Configuration spécifique pour nos loggers
-    for logger_name in ['backend.app.routers.auth']:
-        logger = logging.getLogger(logger_name)
-        logger.setLevel(logging.DEBUG) 
+    root_logger.setLevel(level)
+    root_logger.handlers = [handler]

--- a/backend/app/services/twitch/auth.py
+++ b/backend/app/services/twitch/auth.py
@@ -70,9 +70,9 @@ class TwitchAuthService:
                 "Content-Type": "application/x-www-form-urlencoded"
             }
             
-            logger.warning(f"[Twitch Auth Request] POST {self.settings.token_url}")
-            logger.warning(f"[Twitch Auth Request] Headers: {headers}")
-            logger.warning(f"[Twitch Auth Request] Data: {data}")
+            logger.debug(f"[Twitch Auth Request] POST {self.settings.token_url}")
+            logger.debug(f"[Twitch Auth Request] Headers: {headers}")
+            logger.debug(f"[Twitch Auth Request] Data: {data}")
             
             async with self.client as client:
                 response = await client.post(
@@ -85,7 +85,7 @@ class TwitchAuthService:
                     headers=headers
                 )
                 
-                logger.warning(f"[Twitch Auth Response] Status: {response.status_code}")
+                logger.debug(f"[Twitch Auth Response] Status: {response.status_code}")
                 if response.status_code != 200:
                     logger.error(f"[Twitch Auth Error] Response: {response.text}")
                 
@@ -94,7 +94,7 @@ class TwitchAuthService:
                     
                 response.raise_for_status()
                 data = await response.json()
-                logger.warning("[Twitch Auth Response] Token generated successfully")
+                logger.info("[Twitch Auth Response] Token generated successfully")
                 
             expires_at = datetime.utcnow() + timedelta(seconds=data["expires_in"])
             
@@ -105,7 +105,7 @@ class TwitchAuthService:
             )
             
             await self.token_repository.save_token(token)
-            logger.warning(f"[Twitch Auth] Token saved, expires at: {expires_at}")
+            logger.info(f"[Twitch Auth] Token saved, expires at: {expires_at}")
             return token
             
         except httpx.HTTPError as e:
@@ -137,22 +137,22 @@ class TwitchAuthService:
                 "Client-Id": self.settings.client_id
             }
             
-            logger.info(f"[Twitch Auth Request] GET {self.settings.validate_url}")
-            logger.info(f"[Twitch Auth Request] Headers: {headers}")
+            logger.debug(f"[Twitch Auth Request] GET {self.settings.validate_url}")
+            logger.debug(f"[Twitch Auth Request] Headers: {headers}")
             
             async with self.client as client:
                 response = await client.get(self.settings.validate_url, headers=headers)
                 
-                logger.info(f"[Twitch Auth Response] Status: {response.status_code}")
+                logger.debug(f"[Twitch Auth Response] Status: {response.status_code}")
                 if response.status_code != 200:
-                    logger.info(f"[Twitch Auth Response] Body: {response.text}")
+                    logger.debug(f"[Twitch Auth Response] Body: {response.text}")
                 
                 if response.status_code == 429:
                     raise TwitchError(429, "Rate limit exceeded")
                     
                 if response.status_code == 200:
                     await self.token_repository.update_last_used(token)
-                    logger.info("[Twitch Auth] Token validated successfully")
+                    logger.debug("[Twitch Auth] Token validated successfully")
                     return True
                 
             logger.warning(f"[Twitch Auth] Invalid token response: {response.status_code}")

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,0 +1,18 @@
+import logging
+import importlib
+
+
+def test_root_logger_level_defaults_to_info(monkeypatch):
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    from backend.app.config import logging_config
+    importlib.reload(logging_config)
+    logging_config.setup_logging()
+    assert logging.getLogger().level == logging.INFO
+
+
+def test_root_logger_level_respects_env(monkeypatch):
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    from backend.app.config import logging_config
+    importlib.reload(logging_config)
+    logging_config.setup_logging()
+    assert logging.getLogger().level == logging.DEBUG


### PR DESCRIPTION
## Summary
- Add `LOG_LEVEL` setting (default `INFO`, overridable via env)
- Simplify `logging_config`: single handler, root level driven by env, drop forced `WARNING` on Twitch-specific loggers
- Demote routine Twitch auth request/response logs from `WARNING` → `INFO`/`DEBUG` so `WARNING` keeps its "anomaly" semantics
- New unit tests cover default level and `LOG_LEVEL` env override

Addresses audit item #10 (Logging incohérent).

## Test plan
- [x] `pytest tests/unit/test_logging_config.py tests/unit/test_health.py` passes
- [x] No new regressions vs baseline on `tests/unit/` (pre-existing Twitch auth failures unchanged)
- [ ] Set `LOG_LEVEL=DEBUG` in env, start app, confirm debug logs appear