### PR TITLE
fix(db): centralize MongoDB with singleton client and DI

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,16 +1,35 @@
-# app/database.py
-from pymongo import MongoClient
-from motor.motor_asyncio import AsyncIOMotorClient
+import logging
+
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
+
 from backend.app.config import settings
 
-def get_db():
-    """Get a synchronous MongoDB connection"""
-    client = MongoClient(settings.MONGODB_URL)
-    db = client[settings.MONGODB_DB_NAME]
-    return db
+logger = logging.getLogger(__name__)
 
-async def get_async_db():
-    """Get an asynchronous MongoDB connection"""
-    client = AsyncIOMotorClient(settings.MONGODB_URL)
-    db = client[settings.MONGODB_DB_NAME]
-    return db
+
+class MongoDB:
+    """Singleton-style MongoDB client manager with lifecycle methods."""
+
+    def __init__(self):
+        self.client: AsyncIOMotorClient | None = None
+        self.db: AsyncIOMotorDatabase | None = None
+
+    async def connect(self) -> None:
+        self.client = AsyncIOMotorClient(settings.MONGODB_URL)
+        self.db = self.client[settings.MONGODB_DB_NAME]
+        logger.info(f"Connected to MongoDB: {settings.MONGODB_DB_NAME}")
+
+    async def disconnect(self) -> None:
+        if self.client is not None:
+            self.client.close()
+            self.client = None
+            self.db = None
+            logger.info("Disconnected from MongoDB")
+
+    def get_db(self) -> AsyncIOMotorDatabase:
+        if self.db is None:
+            raise RuntimeError("MongoDB not connected. Call connect() first.")
+        return self.db
+
+
+mongodb = MongoDB()

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,30 +1,31 @@
-from fastapi import Depends, HTTPException, status, Header
 from typing import Optional
-from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
-from functools import lru_cache
 
+from fastapi import HTTPException, Header, status
+from motor.motor_asyncio import AsyncIOMotorDatabase
+
+from backend.app.database import mongodb
 from backend.app.services.twitch_service import TwitchService
-from backend.app.config import settings
+
 
 async def get_db() -> AsyncIOMotorDatabase:
-    """
-    Dépendance pour obtenir une connexion à la base de données MongoDB.
-    Crée une nouvelle connexion par requête pour éviter
-    l'utilisation d'un event loop fermé en serverless.
-    """
-    client = AsyncIOMotorClient(settings.MONGODB_URL)
-    return client[settings.MONGODB_DB_NAME]
+    """Return the shared MongoDB database handle."""
+    return mongodb.get_db()
+
 
 async def get_twitch_service() -> TwitchService:
-    """Get Twitch service instance"""
+    """Get Twitch service instance."""
     service = TwitchService()
     try:
         yield service
     finally:
         await service.close()
 
+
 async def get_twitch_token(authorization: Optional[str] = Header(None)) -> str:
-    """Get token from Authorization header"""
+    """Get token from Authorization header."""
     if authorization and authorization.startswith("Bearer "):
         return authorization.replace("Bearer ", "")
-    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or missing token")
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid or missing token",
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,10 +26,11 @@ async def lifespan(app: FastAPI):
     # === Startup ===
     global scheduler
 
-    # Configuration du cache
+    from .database import mongodb
+    await mongodb.connect()
+
     await setup_cache()
 
-    # Initialisation du scheduler
     scheduler = CacheScheduler(cache_ttl=3600)
     await scheduler.start()
 
@@ -38,6 +39,7 @@ async def lifespan(app: FastAPI):
     # === Shutdown ===
     if scheduler:
         await scheduler.stop()
+    await mongodb.disconnect()
     logger.info("Application stopped")
 
 # Définition des valeurs pour FastAPI

--- a/backend/app/repositories/twitch_repository.py
+++ b/backend/app/repositories/twitch_repository.py
@@ -1,20 +1,16 @@
 from typing import Optional, List
-from motor.motor_asyncio import AsyncIOMotorClient
+from motor.motor_asyncio import AsyncIOMotorDatabase
 from pymongo.errors import PyMongoError
 from ..models.twitch import TwitchGame, TwitchSearchResult, TwitchVideo
-from ..config import settings
 from datetime import datetime, timedelta
 import logging
 
-# Configure logger for debugging
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 class TwitchRepository:
-    def __init__(self):
-        """Initialize the repository with database collections."""
-        self.client = AsyncIOMotorClient(settings.MONGODB_URL)
-        self.db = self.client[settings.MONGODB_DB_NAME]
+    def __init__(self, db: AsyncIOMotorDatabase):
+        """Initialize the repository with an injected database handle."""
+        self.db = db
         self.games_collection = self.db["games"]
         self.search_cache_collection = self.db["search_cache"]
         self._ensure_indexes()
@@ -39,9 +35,8 @@ class TwitchRepository:
             logger.error(f"Error creating indexes: {str(e)}")
 
     async def close(self):
-        """Close database connection"""
-        if self.client:
-            self.client.close()
+        """No-op: the MongoDB client is managed by the app lifespan."""
+        return None
 
     async def get_cached_game_search(self, game_name: str, limit: int = None) -> Optional[TwitchSearchResult]:
         """

--- a/backend/app/services/twitch_service.py
+++ b/backend/app/services/twitch_service.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException
 from pydantic import ValidationError
 
 from backend.app.config import settings
+from backend.app.database import mongodb
 from backend.app.models.twitch import TwitchUser, TwitchToken, TwitchVideo, TwitchGame, TwitchSearchResult
 from backend.app.repositories.token_repository import TokenRepository
 from backend.app.repositories.twitch_repository import TwitchRepository
@@ -23,7 +24,7 @@ class TwitchService:
         self.auth_url = "https://id.twitch.tv/oauth2"
         self.client_id = settings.TWITCH_CLIENT_ID
         self.auth_service = None
-        self.twitch_repository = TwitchRepository()
+        self.twitch_repository = TwitchRepository(mongodb.get_db())
         
         # Cache en mémoire pour les données fréquemment accédées
         self.memory_cache = TTLCache(
@@ -34,9 +35,7 @@ class TwitchService:
     async def _get_auth_service(self) -> TwitchAuthService:
         """Lazy initialization of auth service."""
         if not self.auth_service:
-            from backend.app.dependencies import get_db
-            db = await get_db()
-            token_repository = TokenRepository(db)
+            token_repository = TokenRepository(mongodb.get_db())
             self.auth_service = TwitchAuthService(token_repository)
         return self.auth_service
 

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,0 +1,36 @@
+import pytest
+
+
+def test_mongodb_not_connected_by_default():
+    from backend.app.database import MongoDB
+    db = MongoDB()
+    assert db.client is None
+    assert db.db is None
+
+
+def test_get_db_raises_when_not_connected():
+    from backend.app.database import MongoDB
+    db = MongoDB()
+    with pytest.raises(RuntimeError, match="not connected"):
+        db.get_db()
+
+
+@pytest.mark.asyncio
+async def test_connect_sets_client_and_db():
+    from backend.app.database import MongoDB
+    db = MongoDB()
+    await db.connect()
+    try:
+        assert db.client is not None
+        assert db.db is not None
+        assert db.get_db() is db.db
+    finally:
+        await db.disconnect()
+    assert db.client is None
+    assert db.db is None
+
+
+def test_module_level_singleton_exists():
+    from backend.app import database
+    assert hasattr(database, "mongodb")
+    assert isinstance(database.mongodb, database.MongoDB)


### PR DESCRIPTION
## Summary
Addresses audit items #8 (DB connection incoherence) and #9 (service instances recreating clients).

- Introduce `MongoDB` singleton in `database.py` with `connect()` / `disconnect()` / `get_db()` lifecycle
- `lifespan` opens the client at startup and closes it on shutdown — single shared client, no per-request allocation
- `dependencies.get_db()` now returns the shared handle
- `TwitchRepository` accepts an injected `AsyncIOMotorDatabase` (no more private client, no more per-instance connect)
- `TwitchService` wires both its repository and auth token repository against the shared client
- Drop a stray `logging.basicConfig(level=DEBUG)` that was overriding the app-wide logging setup from PR #14
- New unit tests cover singleton state, failure when not connected, and connect/disconnect behavior

## Test plan
- [x] `pytest tests/unit/test_database.py` — 4 new tests pass
- [x] `pytest tests/unit/` — no new regressions vs baseline (10 pre-existing Twitch auth failures unchanged)
- [ ] Start the app on the server, hit `/api/health` and `/api/v1/search/...`, watch logs for a single "Connected to MongoDB" at startup
- [ ] Confirm a single "Disconnected from MongoDB" log on shutdown