### PR TITLE
infra(A): Dockerfiles backend/frontend + fail-fast prod settings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,47 @@
+# VCS
+.git
+.gitignore
+.github
+
+# Python
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache
+.mypy_cache
+.ruff_cache
+*.egg-info
+venv
+venv-py311
+.venv
+
+# Node
+frontend/node_modules
+frontend/dist
+frontend/.vite
+frontend/playwright-report
+frontend/cypress
+
+# Tests and coverage
+tests
+htmlcov
+.coverage
+coverage.xml
+
+# Editor / OS
+.vscode
+.idea
+.DS_Store
+
+# Secrets / local envs
+.env
+.env.*
+!.env.production.example
+
+# Docs / plans
+docs
+
+# Misc
+*.log
+*.sqlite

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1.6
+FROM python:3.12-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend ./backend
+
+RUN groupadd --system app && useradd --system --gid app --home /app --shell /usr/sbin/nologin app \
+    && chown -R app:app /app
+USER app
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD curl --fail --silent http://127.0.0.1:8000/api/health || exit 1
+
+CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1.6
+
+# ---- Build stage ----
+FROM node:20-alpine AS build
+
+WORKDIR /build
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+COPY frontend/ ./
+RUN npm run build
+
+# ---- Runtime stage ----
+FROM nginx:1.27-alpine AS runtime
+
+# Drop default site config; project-level nginx conf is mounted by compose.
+RUN rm /etc/nginx/conf.d/default.conf
+
+COPY --from=build /build/dist /usr/share/nginx/html
+
+# nginx:alpine already runs worker processes as the 'nginx' user.
+# The master must start as root to bind :80 then drops privileges.
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget --quiet --spider http://127.0.0.1/healthz || exit 1

--- a/backend/app/config/prod.py
+++ b/backend/app/config/prod.py
@@ -1,40 +1,41 @@
-from backend.app.config.base import Settings # Importer depuis le nouveau fichier base.py
+from pydantic import field_validator
 
-class ProdSettings(Settings): # Inherit from base Settings
-    # Environment
+from backend.app.config.base import Settings
+
+# Known placeholder values that must never make it to production.
+_WEAK_SECRETS = {
+    "",
+    "dev-secret-key",
+    "dev-secret-key-12345-changeme-in-production",
+    "changeme",
+    "secret",
+}
+
+
+class ProdSettings(Settings):
     ENVIRONMENT: str = "prod"
-    DEBUG: bool = False # DEBUG must be False in production
-    LOG_LEVEL: str = "INFO" # Standard production log level
-    
-    # Twitch API settings
-    # These will be loaded from .env via Settings, or environment variables.
-    # Ensure these are set in the production environment.
-    # TWITCH_CLIENT_ID: str
-    # TWITCH_CLIENT_SECRET: str
-    # TWITCH_REDIRECT_URI: str
-    
-    # MongoDB settings
-    # MONGODB_URL: str # Loaded from .env via Settings
-    # MONGODB_DB_NAME: str = "dbTwitch" # Can be inherited or overridden
-    
-    # Redis settings
-    # REDIS_URL: str # Loaded from .env via Settings
-    
-    # Session settings
-    # SESSION_SECRET_KEY is required from .env in production
-    # Do NOT fallback to secrets.token_urlsafe() - it will regenerate on each deploy
+    DEBUG: bool = False
+    LOG_LEVEL: str = "INFO"
 
-    # Cache settings - can be inherited or overridden
-    # CACHE_TTL: int = 3600
-    # CACHE_MAX_SIZE: int = 1000
+    # Production must explicitly set allowed origins via .env.
+    ALLOWED_ORIGINS: list[str] = []
 
-    # API_URL - should be the production API URL, loaded from .env via Settings
-    # API_URL: str = os.getenv("API_URL", "http://localhost:8000") # Example
+    @field_validator("SESSION_SECRET_KEY")
+    @classmethod
+    def _session_secret_strong(cls, v: str) -> str:
+        if v in _WEAK_SECRETS:
+            raise ValueError(
+                "SESSION_SECRET_KEY is a known placeholder; set a strong value in .env"
+            )
+        if len(v) < 32:
+            raise ValueError("SESSION_SECRET_KEY must be at least 32 characters long")
+        return v
 
-    # FRONTEND_URL: str = os.getenv("FRONTEND_URL", "http://localhost:5173") # Example
-
-    # CORS settings
-    # Production: set ALLOWED_ORIGINS in .env to comma-separated list
-    # Example: ALLOWED_ORIGINS='["https://yourdomain.com","https://app.yourdomain.com"]'
-    ALLOWED_ORIGINS: list[str] = []  # Prod must explicitly set origins in .env
-
+    @field_validator("ALLOWED_ORIGINS")
+    @classmethod
+    def _origins_not_empty(cls, v: list[str]) -> list[str]:
+        if not v:
+            raise ValueError(
+                "ALLOWED_ORIGINS must be set in production (comma-separated JSON list)"
+            )
+        return v

--- a/tests/unit/config/test_prod_settings.py
+++ b/tests/unit/config/test_prod_settings.py
@@ -1,0 +1,57 @@
+import pytest
+from pydantic import ValidationError
+
+
+def _base_env(**overrides):
+    env = {
+        "TWITCH_CLIENT_ID": "x",
+        "TWITCH_CLIENT_SECRET": "y",
+        "TWITCH_REDIRECT_URI": "https://example.com/cb",
+        "MONGODB_URL": "mongodb://mongo:27017",
+        "REDIS_URL": "redis://redis:6379",
+        "SESSION_SECRET_KEY": "a" * 40,
+        "ALLOWED_ORIGINS": '["https://example.com"]',
+    }
+    env.update(overrides)
+    return env
+
+
+def _instantiate(monkeypatch, **overrides):
+    for k, v in _base_env(**overrides).items():
+        monkeypatch.setenv(k, v)
+    monkeypatch.setenv("ENVIRONMENT", "prod")
+    from backend.app.config.prod import ProdSettings
+    return ProdSettings(_env_file=None)
+
+
+def test_valid_prod_settings(monkeypatch):
+    s = _instantiate(monkeypatch)
+    assert s.SESSION_SECRET_KEY == "a" * 40
+    assert s.ALLOWED_ORIGINS == ["https://example.com"]
+
+
+def test_reject_placeholder_session_secret(monkeypatch):
+    with pytest.raises(ValidationError, match="placeholder"):
+        _instantiate(monkeypatch, SESSION_SECRET_KEY="dev-secret-key")
+
+
+def test_reject_short_session_secret(monkeypatch):
+    with pytest.raises(ValidationError, match="32 characters"):
+        _instantiate(monkeypatch, SESSION_SECRET_KEY="short")
+
+
+def test_reject_empty_allowed_origins(monkeypatch):
+    with pytest.raises(ValidationError, match="ALLOWED_ORIGINS"):
+        _instantiate(monkeypatch, ALLOWED_ORIGINS="[]")
+
+
+def test_missing_required_field_fails_fast(monkeypatch):
+    for k, v in _base_env().items():
+        if k == "MONGODB_URL":
+            continue
+        monkeypatch.setenv(k, v)
+    monkeypatch.setenv("ENVIRONMENT", "prod")
+    monkeypatch.delenv("MONGODB_URL", raising=False)
+    from backend.app.config.prod import ProdSettings
+    with pytest.raises(ValidationError, match="MONGODB_URL"):
+        ProdSettings(_env_file=None)

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -118,12 +118,13 @@ def test_debug_false_in_prod():
     """DEBUG must be False in production"""
     with patch.dict(os.environ, {
         "ENVIRONMENT": "prod",
-        "SESSION_SECRET_KEY": "test-secret",
+        "SESSION_SECRET_KEY": "x" * 40,
         "TWITCH_CLIENT_ID": "test-id",
         "TWITCH_CLIENT_SECRET": "test-secret",
         "TWITCH_REDIRECT_URI": "http://localhost:8000/callback",
         "MONGODB_URL": "mongodb://test",
-        "REDIS_URL": "redis://test"
+        "REDIS_URL": "redis://test",
+        "ALLOWED_ORIGINS": '["https://example.com"]',
     }):
         from backend.app.config.prod import ProdSettings
         settings = ProdSettings()


### PR DESCRIPTION
## Summary
First slice of the deployment infra (PR A of the infra plan).

**Docker images (separate, as agreed):**
- `Dockerfile.backend` — `python:3.12-slim`, non-root `app` user, `curl`-based `HEALTHCHECK` on `/api/health`, uvicorn entrypoint
- `Dockerfile.frontend` — multi-stage: `node:20-alpine` builds the Vue app, `nginx:1.27-alpine` serves `/usr/share/nginx/html`. Default nginx conf dropped; the project-level `nginx/nginx.conf` will be mounted by compose in PR B
- `.dockerignore` — keeps the build context lean (excludes venvs, node_modules, tests, docs, local envs; keeps `.env.production.example`)

**Fail-fast configuration:**
- `ProdSettings` now rejects at startup:
  - any `SESSION_SECRET_KEY` shorter than 32 chars or matching a known placeholder
  - empty `ALLOWED_ORIGINS`
- Pydantic already fails on missing required fields (`MONGODB_URL`, `TWITCH_CLIENT_ID`, etc.); added a test that locks this behavior in
- `test_debug_false_in_prod` updated to satisfy the new rules

## Out of scope (handled in later PRs)
- `compose.yml` / `compose.prod.yml`, `nginx/nginx.conf`, healthchecks across services → **PR B**
- `deploy/` runbook, `streamzilla.service`, `init-letsencrypt.sh` → **PR C**
- `.github/workflows/ci.yml` → **PR D**

## Test plan
- [x] `pytest tests/unit/config/test_prod_settings.py` — 5 new tests pass
- [x] `pytest tests/unit/` — no new regressions vs baseline (10 pre-existing Twitch auth failures unchanged)
- [ ] On the server: `docker build -f Dockerfile.backend -t streamzilla-backend .` succeeds
- [ ] `docker build -f Dockerfile.frontend -t streamzilla-frontend .` succeeds
- [ ] Running backend image with missing `SESSION_SECRET_KEY` crashes immediately with a clear error