### PR TITLE
infra(B): docker compose stack + nginx reverse proxy

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,41 @@
+# Copy this file to `.env` on the server and fill in the real values.
+# NEVER commit the resulting `.env`.
+
+# ---- App ----------------------------------------------------------------
+ENVIRONMENT=prod
+LOG_LEVEL=INFO
+DEBUG=false
+
+# Must be at least 32 chars and not a known placeholder.
+# Generate with: python -c "import secrets; print(secrets.token_urlsafe(48))"
+SESSION_SECRET_KEY=
+
+# JSON list of origins allowed by CORS; must not be empty in prod.
+# Example once a domain is in place: ["https://your.domain.tld"]
+ALLOWED_ORIGINS=["http://SERVER_IP"]
+
+# Public base URL of the API (used for Twitch redirect, links, etc.).
+API_URL=http://SERVER_IP
+FRONTEND_URL=http://SERVER_IP
+
+# ---- Twitch -------------------------------------------------------------
+TWITCH_CLIENT_ID=
+TWITCH_CLIENT_SECRET=
+TWITCH_REDIRECT_URI=http://SERVER_IP/api/v1/auth/callback
+
+# ---- MongoDB ------------------------------------------------------------
+# Root account: used only by the initdb step, never by the app.
+MONGO_ROOT_USERNAME=root
+MONGO_ROOT_PASSWORD=
+
+# Application database and scoped user.
+MONGO_APP_DB=streamzilla
+MONGO_APP_USERNAME=streamzilla
+MONGO_APP_PASSWORD=
+
+# ---- Redis --------------------------------------------------------------
+REDIS_PASSWORD=
+
+# ---- Derived (the compose file builds these; no need to override) -------
+# MONGODB_URL and REDIS_URL are constructed in compose.yml from the values
+# above so they always stay consistent with the credentials set here.

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,0 +1,24 @@
+services:
+  backend:
+    restart: unless-stopped
+    # Prod: crash-loop fast if startup is wrong so we notice instead of a
+    # slow retry burning resources.
+    healthcheck:
+      interval: 15s
+      timeout: 3s
+      start_period: 10s
+      retries: 5
+
+  frontend:
+    restart: unless-stopped
+    healthcheck:
+      interval: 15s
+      timeout: 3s
+      start_period: 5s
+      retries: 5
+
+  mongodb:
+    restart: unless-stopped
+
+  redis:
+    restart: unless-stopped

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,88 @@
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    env_file:
+      - .env
+    environment:
+      # Backend reaches the DB via the internal compose network.
+      MONGODB_URL: "mongodb://${MONGO_APP_USERNAME}:${MONGO_APP_PASSWORD}@mongodb:27017/${MONGO_APP_DB}?authSource=${MONGO_APP_DB}"
+      MONGODB_DB_NAME: "${MONGO_APP_DB}"
+      REDIS_URL: "redis://:${REDIS_PASSWORD}@redis:6379/0"
+    depends_on:
+      mongodb:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "http://127.0.0.1:8000/api/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    depends_on:
+      backend:
+        condition: service_healthy
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--spider", "http://127.0.0.1/healthz"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
+
+  mongodb:
+    image: mongo:7
+    command: ["--bind_ip_all"]
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: "${MONGO_ROOT_USERNAME}"
+      MONGO_INITDB_ROOT_PASSWORD: "${MONGO_ROOT_PASSWORD}"
+      MONGO_INITDB_DATABASE: "${MONGO_APP_DB}"
+      MONGO_APP_DB: "${MONGO_APP_DB}"
+      MONGO_APP_USERNAME: "${MONGO_APP_USERNAME}"
+      MONGO_APP_PASSWORD: "${MONGO_APP_PASSWORD}"
+    volumes:
+      - mongo_data:/data/db
+      - ./deploy/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
+    healthcheck:
+      test:
+        - "CMD"
+        - "mongosh"
+        - "--quiet"
+        - "-u"
+        - "${MONGO_ROOT_USERNAME}"
+        - "-p"
+        - "${MONGO_ROOT_PASSWORD}"
+        - "--authenticationDatabase"
+        - "admin"
+        - "--eval"
+        - "db.adminCommand('ping').ok"
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD}", "--save", "60", "1"]
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "--no-auth-warning", "ping"]
+      interval: 30s
+      timeout: 5s
+      start_period: 5s
+      retries: 3
+
+volumes:
+  mongo_data:
+  redis_data:

--- a/deploy/mongo-init.js
+++ b/deploy/mongo-init.js
@@ -1,0 +1,21 @@
+// Runs once on first MongoDB startup (mounted into /docker-entrypoint-initdb.d/).
+// Creates an application user scoped to the app database with readWrite only.
+// Root credentials are provided via MONGO_INITDB_ROOT_USERNAME / MONGO_INITDB_ROOT_PASSWORD.
+
+const appDb = process.env.MONGO_APP_DB;
+const appUser = process.env.MONGO_APP_USERNAME;
+const appPassword = process.env.MONGO_APP_PASSWORD;
+
+if (!appDb || !appUser || !appPassword) {
+    throw new Error(
+        "MONGO_APP_DB, MONGO_APP_USERNAME and MONGO_APP_PASSWORD must be set " +
+        "in the environment when initializing MongoDB."
+    );
+}
+
+db = db.getSiblingDB(appDb);
+db.createUser({
+    user: appUser,
+    pwd: appPassword,
+    roles: [{ role: "readWrite", db: appDb }],
+});

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,49 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    client_max_body_size 10M;
+    proxy_connect_timeout 10s;
+    proxy_send_timeout    30s;
+    proxy_read_timeout    30s;
+
+    # Lightweight healthcheck used by the container HEALTHCHECK.
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "ok\n";
+    }
+
+    # Backend API (FastAPI, internal service "backend" in compose).
+    location /api/ {
+        proxy_pass http://backend:8000;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_redirect off;
+        proxy_buffering on;
+    }
+
+    # SPA: serve static assets, fall back to index.html for client-side routes.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # --- TLS block, activated once a domain and Let's Encrypt certs are in place.
+    # server {
+    #     listen 443 ssl http2;
+    #     server_name your.domain.tld;
+    #     ssl_certificate     /etc/letsencrypt/live/your.domain.tld/fullchain.pem;
+    #     ssl_certificate_key /etc/letsencrypt/live/your.domain.tld/privkey.pem;
+    #     include /etc/letsencrypt/options-ssl-nginx.conf;
+    #     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+    #     # ... same locations as above ...
+    # }
+}


### PR DESCRIPTION
## Summary
Second slice of the deployment infra (PR B of the infra plan).

**Compose stack (4 services, internal network):**
- `backend` — FastAPI image built from `Dockerfile.backend`, reaches MongoDB and Redis via the compose network, `/api/health` healthcheck, no published port
- `frontend` — nginx image built from `Dockerfile.frontend`, mounts `nginx/nginx.conf`, publishes `80:80`, `/healthz` healthcheck
- `mongodb` — `mongo:7` with auth, init script provisions a scoped app user, healthcheck via `mongosh ping`, data persisted in `mongo_data`
- `redis` — `redis:7-alpine` with `--requirepass`, healthcheck via `redis-cli ping`, data persisted in `redis_data`
- `depends_on: condition: service_healthy` so startup order respects readiness

**nginx config:**
- serves the built Vue dist with SPA fallback (`try_files $uri /index.html`)
- proxies `/api/` to `backend:8000`, forwards `X-Forwarded-*`
- explicit timeouts (`client_max_body_size 10M`, `proxy_read/connect/send_timeout`)
- commented `443` block ready for Let's Encrypt in PR C

**Security posture:**
- Only the frontend (nginx) is reachable from outside; backend/mongo/redis live on the internal compose network
- MongoDB root is used only by the init step; the app authenticates as a `readWrite`-scoped user
- Redis protected by `requirepass`
- `MONGODB_URL` / `REDIS_URL` are built inside compose from the credentials it controls, so the two can't drift

**`.env.production.example`**
- Documents every required variable with generation hints (e.g. `python -c "import secrets; ..."`)
- Explicitly tells the operator not to override `MONGODB_URL` / `REDIS_URL`

## Out of scope (later PRs)
- `deploy/deploy.md`, `deploy/streamzilla.service`, `deploy/init-letsencrypt.sh` → **PR C**
- `.github/workflows/ci.yml` → **PR D**

## Test plan
- [x] `docker compose -f compose.yml -f compose.prod.yml config` parses without error
- [ ] On the server: copy `.env.production.example` to `.env`, fill in secrets, then `docker compose -f compose.yml -f compose.prod.yml up -d --build`
- [ ] `docker compose ps` shows all 4 services `healthy`
- [ ] `curl http://SERVER_IP/healthz` → `ok`
- [ ] `curl http://SERVER_IP/api/health` → `{"status":"ok"}`
- [ ] App loads in browser at `http://SERVER_IP`
- [ ] `docker compose exec mongodb mongosh -u $MONGO_APP_USERNAME -p $MONGO_APP_PASSWORD --authenticationDatabase $MONGO_APP_DB` can write to the app db but not to `admin`